### PR TITLE
Add Book content type support

### DIFF
--- a/src/lib/oorlogsbronnen-api.ts
+++ b/src/lib/oorlogsbronnen-api.ts
@@ -1,15 +1,16 @@
 import { SearchParams, SearchResponse } from '../types/index.js';
 
 // Define allowed content types for filtering
-export const CONTENT_TYPES = [
-  'Person',
-  'Photograph',
-  'Article',
-  'VideoObject', 
-  'Thing',
-  'Place',
-  'CreativeWork'
-] as const;
+export const CONTENT_TYPES = {
+  PERSON: 'Person',
+  PHOTO: 'Photograph',
+  ARTICLE: 'Article',
+  VIDEO: 'VideoObject',
+  OBJECT: 'Thing',
+  LOCATION: 'Place',
+  CREATIVE_WORK: 'CreativeWork',
+  BOOK: 'Book'
+} as const;
 
 export class OorlogsbronnenClient {
   private baseUrl = 'https://rest.spinque.com/4/netwerkoorlogsbronnen/api/in10';

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -198,7 +198,7 @@ server.tool(
       "places (e.g., 'Rotterdam'), dates (e.g., '1940-1945'), events (e.g., 'February Strike 1941'), " +
       "or any combination of these. For better results, consider translating key terms to Dutch."
     ),
-    type: z.enum(['Person', 'Photograph', 'Article', 'VideoObject', 'Thing', 'Place', 'CreativeWork']).optional().describe(
+    type: z.enum(['Person', 'Photograph', 'Article', 'VideoObject', 'Thing', 'Place', 'CreativeWork', 'Book']).optional().describe(
       "Filter results by content type. Leave empty for more comprehensive results across all content types. Available types:\n" +
       "- 'Person': Individual biographical records\n" +
       "- 'Photograph': Historical photographs\n" +
@@ -206,7 +206,8 @@ server.tool(
       "- 'VideoObject': Video footage\n" +
       "- 'Thing': Physical artifacts\n" +
       "- 'Place': Places and geographical records\n" +
-      "- 'CreativeWork': Miscellaneous objects, manuscripts, and documents (shows as 'Object' in Dutch interface)"
+      "- 'CreativeWork': Miscellaneous objects, manuscripts, and documents (shows as 'Object' in Dutch interface)\n" +
+      "- 'Book': Published books and monographs"
     ),
     count: z.number().min(1).max(100).optional().describe(
       "Number of results to return (1-100, default: 50). Larger numbers provide more comprehensive results " +
@@ -225,7 +226,8 @@ server.tool(
         VideoObject: { count: 0, items: [] },
         Thing: { count: 0, items: [] },
         Place: { count: 0, items: [] },
-        CreativeWork: { count: 0, items: [] }
+        CreativeWork: { count: 0, items: [] },
+        Book: { count: 0, items: [] }
       };
 
       // If type is specified, we only need to search that category

--- a/test-search-book.cjs
+++ b/test-search-book.cjs
@@ -1,4 +1,4 @@
-const { OorlogsbronnenClient } = require('./dist/lib/oorlogsbronnen-api');
+const { OorlogsbronnenClient, CONTENT_TYPES } = require('./dist/lib/oorlogsbronnen-api');
 
 async function main() {
   const client = new OorlogsbronnenClient();
@@ -6,9 +6,9 @@ async function main() {
   console.log('Searching for "101st Airborne Division" with type filter for "Book"');
   console.log('This should use class:FILTER in the URL');
   
-  const results = await client.search({ 
+  const results = await client.search({
     query: '101st Airborne Division',
-    type: 'Book',
+    type: CONTENT_TYPES.BOOK,
     count: 20 // Request more results to ensure we find books
   });
   


### PR DESCRIPTION
## Summary
- add a BOOK entry to `CONTENT_TYPES`
- allow `Book` in search enum and categories
- update book example script to use the new constant

## Testing
- `npm run build` *(fails: Cannot find type definition file)*
- `npm test` *(fails: jest: not found)*